### PR TITLE
Sigmax implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Signalen in Amsterdam project. Related code:
 This project comes with a docker-compose file that will build a self contained development
 environment (with bind mounts for the web application source).
 
+Set the `SIGMAX_SERVER` and `SIGMAX_AUTH_TOKEN` environment variables to appropriate
+values (these are secret, so not included with the source).
+
 ```sh
 docker-compose up --build
 ```

--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@ Service that sends the required messages to external APIs. This belongs to the
 Signalen in Amsterdam project. Related code:
 * [Central backend application for "Signalen in Amsterdam"](https://github.com/Amsterdam/signals)
 * [Front-end code for "Signalen in Amsterdam"](https://github.com/Amsterdam/signals-frontend)
+
+## Prerequisites
+
+* `docker-compose`
+
+
+## Running the code
+
+*Note: this code is still very much work in progress.*
+
+This project comes with a docker-compose file that will build a self contained development
+environment (with bind mounts for the web application source).
+
+```sh
+docker-compose up --build
+```
+
+The service will now run on http://localhost:8000/signals_export , complete with Redoc documentation
+on http://localhost:8000/signals_export/redoc/.
+
+## Running the test suite
+
+``sh
+docker-compose run web --rm python manage.py test
+``

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       DATABASE_NAME: signalsexport
       DATABASE_USER: signalsexport
       DATABASE_PASSWORD: insecure
+
+      # The following are secrets to external APIs:
+      SIGMAX_AUTH_TOKEN:
+      SIGMAX_SERVER:
     ports:
       - "8000:8000"
     volumes:

--- a/web/app/datasets/external/sigmax.py
+++ b/web/app/datasets/external/sigmax.py
@@ -3,14 +3,78 @@ Send messages to the external Sigmax API.
 
 Minimal implementation based on work by Maarten Sukel.
 """
+import os
 import logging
 import datetime
+import requests
+from xml.sax.saxutils import escape
 
 from datasets.external.base import BaseAPIHandler
 
 LOG_FORMAT = '%(asctime)-15s - %(name)s - %(message)s'
 logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
+# -- format string for message generation --
+
+PLACEHOLDER_STRING = 'PLACEHOLDER'
+TEMPLATE =\
+u"""<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+       <soap:Body>
+          <ZKN:zakLk01 xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:gml="http://www.opengis.net/gml" xmlns:bag="http://www.vrom.nl/bag/0120" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:StUF="http://www.egem.nl/StUF/StUF0301" xmlns:tns="http://www.circlesoftware.nl/verseon/mng/webservice/2012" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xlink="http://www.w3.org/1999/xlink">
+             <ZKN:stuurgegevens>
+                <StUF:berichtcode>Lk01</StUF:berichtcode>
+                <StUF:zender>
+                   <StUF:organisatie>AMS</StUF:organisatie>
+                   <StUF:applicatie>VER</StUF:applicatie>
+                </StUF:zender>
+                <StUF:ontvanger>
+                   <StUF:organisatie>SMX</StUF:organisatie>
+                   <StUF:applicatie>CTC</StUF:applicatie>
+                </StUF:ontvanger>
+                <StUF:referentienummer>{PRIMARY_KEY}</StUF:referentienummer>
+                <StUF:tijdstipBericht>{TIJDSTIPBERICHT}</StUF:tijdstipBericht>
+                <StUF:entiteittype>ZAK</StUF:entiteittype>
+             </ZKN:stuurgegevens>
+             <ZKN:parameters>
+                <StUF:mutatiesoort>T</StUF:mutatiesoort>
+                <StUF:indicatorOvername>V</StUF:indicatorOvername>
+             </ZKN:parameters>
+             <ZKN:object StUF:entiteittype="ZAK" StUF:sleutelGegevensbeheer="" StUF:verwerkingssoort="T">
+                <ZKN:identificatie>{PRIMARY_KEY}</ZKN:identificatie>
+                <ZKN:omschrijving>{OMSCHRIJVING}</ZKN:omschrijving>
+                <ZKN:startdatum>{STARTDATUM}</ZKN:startdatum>
+                <ZKN:registratiedatum>{REGISTRATIEDATUM}</ZKN:registratiedatum>
+                <ZKN:einddatumGepland>{EINDDATUMGEPLAND}</ZKN:einddatumGepland>
+                <ZKN:archiefnominatie>N</ZKN:archiefnominatie>
+                <ZKN:zaakniveau>1</ZKN:zaakniveau>
+                <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>
+                <StUF:extraElementen>
+                   <StUF:extraElement naam="Ycoordinaat">{EINDDATUMGEPLAND}</StUF:extraElement>
+                   <StUF:extraElement naam="Xcoordinaat">{EINDDATUMGEPLAND}</StUF:extraElement>
+                </StUF:extraElementen>
+                <ZKN:isVan StUF:entiteittype="ZAKZKT" StUF:verwerkingssoort="T">
+                   <ZKN:gerelateerde StUF:entiteittype="ZKT" StUF:sleutelOntvangend="1" StUF:verwerkingssoort="T">
+                      <ZKN:omschrijving>Uitvoeren controle</ZKN:omschrijving>
+                      <ZKN:code>2</ZKN:code>
+                   </ZKN:gerelateerde>
+                </ZKN:isVan>
+                <ZKN:heeftBetrekkingOp StUF:entiteittype="ZAKOBJ" StUF:verwerkingssoort="T">
+                   <ZKN:gerelateerde>
+                      <ZKN:adres StUF:entiteittype="AOA" StUF:verwerkingssoort="T">
+                         <BG:wpl.woonplaatsNaam>Amsterdam</BG:wpl.woonplaatsNaam>
+                         <BG:gor.openbareRuimteNaam>{OPENBARERUIMTENAAM}</BG:gor.openbareRuimteNaam>
+                         <BG:huisnummer>{HUISNUMMER}</BG:huisnummer>
+                         <BG:huisletter StUF:noValue="geenWaarde" xsi:nil="true"/>
+                         <BG:postcode>{POSTCODE}</BG:postcode>
+                      </ZKN:adres>
+                   </ZKN:gerelateerde>
+                </ZKN:heeftBetrekkingOp>
+             </ZKN:object>
+          </ZKN:zakLk01>
+       </soap:Body>
+    </soap:Envelope>"""
+
 
 # -- helper functions --
 def _format_datetime(dt):
@@ -23,20 +87,64 @@ def _format_date(dt):
     return dt.strftime('%Y%m%d')
 
 
+class ServiceNotConfigured(Exception):
+    pass
+
+
 # -- functions that generate or send messages --
 
 def _generate_stuf_message(signal):
     """
     Generate the XML needed for Sigmax.
     """
-    pass
+    return TEMPLATE.format(**{
+        'PRIMARY_KEY': escape(signal['signal_id']),
+        'OMSCHRIJVING': escape('Dit is een test bericht'),
+        'TIJDSTIPBERICHT': escape(PLACEHOLDER_STRING),
+        'STARTDATUM': escape(PLACEHOLDER_STRING),
+        'REGISTRATIEDATUM': escape(PLACEHOLDER_STRING),
+        'EINDDATUMGEPLAND': escape(PLACEHOLDER_STRING),
+        'OPENBARERUIMTENAAM': escape(PLACEHOLDER_STRING),
+        'HUISNUMMER': escape(PLACEHOLDER_STRING),
+        'POSTCODE': escape(PLACEHOLDER_STRING),
+    })
 
 
 def _send_stuf_message(stuf_msg):
     """
     Send a STUF message to the server that is configured.
     """
-    pass
+    # Grab credentials from environment (assumption, these are set for
+    # either testing or production --- not configurable at run time).
+    SIGMAX_AUTH_TOKEN = os.getenv('SIGMAX_AUTH_TOKEN', None)
+    SIGMAX_SERVER = os.getenv('SIGMAX_SERVER', None)
+    logger.debug('SIGMAX_SERVER: {}'.format(SIGMAX_SERVER))
+    logger.debug('SIGMAX_AUTH_TOKEN: {}'.format(SIGMAX_AUTH_TOKEN))
+
+    if not SIGMAX_AUTH_TOKEN or not SIGMAX_SERVER:
+        msg = 'SIGMAX_AUTH_TOKEN or SIGMAX_SERVER not configured.'
+        raise ServiceNotConfigured(msg)
+
+    # Prepare our request to Sigmax
+    encoded = stuf_msg.encode('utf-8')
+    headers = {
+        'SOAPAction': 'http://www.egem.nl/StUF/sector/zkn/0310/CreeerZaak_Lk01',
+        'Content-Type': 'text/xml; charset=UTF-8',
+        'Authorization': 'Basic ' + SIGMAX_AUTH_TOKEN,
+        'Content-Length': bytes(len(encoded))
+    }
+
+    # Send our message to Sigmax
+    response = requests.post(
+        url=SIGMAX_SERVER,
+        headers=headers,
+        data=encoded,
+        verify=False
+    )
+
+    # We return the response object sot that we can check the response from
+    # the external API handler.
+    return response
 
 
 # -- Sigmax API Handler --
@@ -46,4 +154,4 @@ class SigmaxHandler(BaseAPIHandler):
         pass
 
     def can_handle(self, signal):
-        pass
+        pass # TODO: integrate with "signals" API

--- a/web/app/datasets/external/sigmax.py
+++ b/web/app/datasets/external/sigmax.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 # -- format string for message generation --
 
-PLACEHOLDER_STRING = 'PLACEHOLDER'
+PLACEHOLDER_STRING = ''
 TEMPLATE =\
 u"""<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
        <soap:Body>

--- a/web/app/datasets/external/sigmax.py
+++ b/web/app/datasets/external/sigmax.py
@@ -142,7 +142,7 @@ def _send_stuf_message(stuf_msg):
         verify=False
     )
 
-    # We return the response object sot that we can check the response from
+    # We return the response object so that we can check the response from
     # the external API handler.
     return response
 

--- a/web/app/datasets/external/test_sigmax.py
+++ b/web/app/datasets/external/test_sigmax.py
@@ -4,6 +4,8 @@ Test suite for Sigmax message generation.
 import logging
 import time
 import datetime
+from unittest import mock
+from lxml import etree
 
 from django.test import TestCase
 
@@ -12,6 +14,7 @@ from datasets.external import sigmax
 
 LOG_FORMAT = '%(asctime)-15s - %(name)s - %(message)s'
 logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG)
+logging.disable(logging.NOTSET)
 logger = logging.getLogger(__name__)
 
 class TestSigmaxHelpers(TestCase):
@@ -47,3 +50,69 @@ class TestSigmaxHelpers(TestCase):
         with self.assertRaises(AttributeError):
             t = time.time()
             sigmax._format_date(t)
+
+
+class TestGenerateStufMessage(TestCase):
+    def test_is_xml(self):
+        signal = {'signal_id': 'ABACADABRA'}
+        xml = sigmax._generate_stuf_message(signal)
+
+        try:
+            root = etree.fromstring(xml)
+        except:
+            self.fail('Cannot parse STUF message as XML')
+
+    def test_escaping(self):
+        poison = {'signal_id': '<poison>tastes nice</poison>'}
+        msg = sigmax._generate_stuf_message(poison)
+        self.assertTrue('<poison>' not in msg)
+
+
+def show_args_kwargs(*args, **kwargs):
+    return args, kwargs
+
+
+class TestSendStufMessage(TestCase):
+    def test_no_environment_variables(self):
+        # Check that missing enviroment variables for server and auth token
+        # raises an error when a message is sent.
+        env_override = {'SIGMAX_AUTH_TOKEN': '', 'SIGMAX_SERVER': ''}
+
+        with mock.patch.dict('os.environ', env_override):
+            with self.assertRaises(sigmax.ServiceNotConfigured):
+                sigmax._send_stuf_message('TEST BERICHT')
+
+
+    @mock.patch('requests.post', side_effect=show_args_kwargs)
+    def test_send_message(self, request_post_mock):
+        # Check that headers are set correctly when sending an STUF message.
+        message = 'TEST BERICHT'
+        env_override = {
+            'SIGMAX_AUTH_TOKEN': 'SLEUTEL',
+            'SIGMAX_SERVER': 'TESTSERVER',
+        }
+
+        with mock.patch.dict('os.environ', env_override):
+            args, kwargs = sigmax._send_stuf_message(message)
+
+            self.assertEquals(request_post_mock.called, 1)
+            self.assertEquals(kwargs['url'], 'TESTSERVER')
+            self.assertEquals(
+                kwargs['headers']['Authorization'],
+                'Basic SLEUTEL'
+            )
+            self.assertEquals(
+                kwargs['headers']['SOAPAction'],
+                'http://www.egem.nl/StUF/sector/zkn/0310/CreeerZaak_Lk01'
+            )
+            self.assertEquals(
+                kwargs['headers']['Content-Type'],
+                'text/xml; charset=UTF-8'
+            )
+            self.assertEquals(
+                bytes(len(message)),
+                kwargs['headers']['Content-Length']
+            )
+
+
+

--- a/web/app/datasets/management/commands/handle_signals.py
+++ b/web/app/datasets/management/commands/handle_signals.py
@@ -15,6 +15,4 @@ class Command(BaseCommand):
     help = 'Retrieve signals from signal API and send messages if needed.'
 
     def handle(self, *args, **options):
-        self.stdout.write('Not yet implemented')
         handle_signals()
-

--- a/web/app/datasets/management/commands/send_signal_to_sigmax.py
+++ b/web/app/datasets/management/commands/send_signal_to_sigmax.py
@@ -1,0 +1,27 @@
+import os
+import uuid
+
+from django.core.management.base import BaseCommand, CommandError
+
+from datasets.external.sigmax import _generate_stuf_message, _send_stuf_message
+
+
+# Known to still be problematic, work in progress
+class Command(BaseCommand):
+    help = 'Send a message to "Sigmax" as a manual test.'
+
+    def handle(self, *args, **options):
+        self.stdout.write('Send a message to Sigmax.')
+        msg = _generate_stuf_message({
+            'signal_id': 'TEST MESSAGE FROM AMSTERDAM ' + str(uuid.uuid4())
+        })
+
+        self.stdout.write('Hier het bericht:')
+        self.stdout.write(msg)
+        self.stdout.write('Einde bericht')
+
+        self.stdout.write('Sending a message to Sigmax.')
+        r = _send_stuf_message(msg)
+        self.stdout.write('response status code: {}'.format(r.status_code))
+        self.stdout.write('Logging response.text :')
+        self.stdout.write(r.text)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -28,3 +28,4 @@ drf-yasg
 drf-yasg[validation]
 swagger-spec-validator
 flex
+lxml


### PR DESCRIPTION
Message generation + manage.py command + tests. We still have some validation problems at the test server / de WDSL specs - this is worked on in parallel.

Running locally you should be able to run the tests that cover message generation, and be able to send a message using **python manage.py send_signal_to_sigmax.py** (still WIP, but we get 200s). Comments are welcome.